### PR TITLE
BugFix: --database option not works

### DIFF
--- a/django/core/management/commands/dumpdata.py
+++ b/django/core/management/commands/dumpdata.py
@@ -13,6 +13,7 @@ class ProxyModelWarning(Warning):
 
 
 class Command(BaseCommand):
+    requires_system_checks = False
     help = (
         "Output the contents of the database as a fixture of the given format "
         "(using each model's default manager unless --all is specified)."


### PR DESCRIPTION
Because of system checks before loading the module
So, we need to disable system checks as I committed.